### PR TITLE
docs: Fix duplicate documentation tag

### DIFF
--- a/doc/smartbraces.txt
+++ b/doc/smartbraces.txt
@@ -13,7 +13,7 @@ This Vim plug-in makes
 
 ===========================================================================
 1. Config ~
-                                    *SmartBraces-config* *SmartBraces-config*
+                                    *SmartBraces-config* *smartbraces-config*
 
 The following mappings with the following default values are available:
 >


### PR DESCRIPTION
Having duplicate tags throws an execution warning when building docs with some plugin managers, e.g. rocks.nvim fails to install this plugin at all.